### PR TITLE
ci: pre-commit tools to catch erroros sooner

### DIFF
--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -1,0 +1,26 @@
+---
+# cSpell Settings
+
+# Done in YAML rather than JSON because -- like XML -- there is a cleary-documented way to write
+# comments that don't hit-or-miss fail on some parsers.  Some folks felt we were miles ahead of XML
+# with JSON; someday, JSON will even reach parity!
+
+version: "0.2"
+
+# flagWords - list of words to be always considered incorrect
+# This is useful for offensive words and common spelling errors.
+# For example "hte" should be "the"
+flagWords:
+  - hte
+  - ot
+
+language: en
+
+# words - list of words to be always considered correct: an Allowlist per-se
+words:
+  - allanc
+  - bitrot
+  - chickenandpork
+  - kwargs
+  - osbee
+  - srcs

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    }
+  ],
+  "regexManagers": [
+   {
+     "fileMatch": [".github/workflows/.*.yml"],
+      "matchStrings": [
+        "renovatebot datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    }
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+# To install the dependencies for this file:
+# 1) pip install pre-commit
+#   (really, "sudo python3 -m pip install pre-commit")
+#   (really, I've been carrying this boilerplate for years, but now it's all python3?)
+#
+# 2) pre-commit install --allow-missing-config
+#
+# yamllint checks this .pre-commit-config file as well
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: ["-d", "{extends: relaxed, rules: {line-length: {max: 120}}}"]
+  # Enforce that commit messages are semantic-commits, compatible with release-please
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.27.0
+    hooks:
+      - id: commitizen
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.4
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.8.2
+    hooks:
+      - id: cspell
+        # a local allowlist of dictionary words in .github/cspell.yaml.  This can get comical --
+        # adding new words in every PR -- but the cost/benefit balance may avoid some embarassing
+        # typos
+        args: ["--config", ".github/cspell.yaml"]
+        types: [file, markdown]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# osbee-utils
+# osbee
 Utilities for OSBee-3.0 device from OpenSprinkler


### PR DESCRIPTION
Some basic boilerplate of self-check facilities:
 - pre-commit: why let catchable errors slip through?
    - runs black
    - runs cspell
    - runs yamllint
    - checks for conventional commits to be reaped by release-please
 - activates RenovateBot
 