### PR TITLE
fix: unblock release by triggering release/publish on please-release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,6 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     environment:
       name: pypi
       url: https://pypi.org/p/osbee


### PR DESCRIPTION
I accidentally blocked the please-release logic on whether a rev is tagged, but please-release needs to run every time, and use it's own logic (whether it created a release) to trigger publish.  In this way, a release is published, all brokered by accepting a release PR