### PR TITLE
docs: rename deps updates to show in release notes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,17 +8,19 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "automerge": true,
+      "matchUpdateTypes": ["patch", "minor"]
     }
   ],
   "regexManagers": [
-   {
-     "fileMatch": [".github/workflows/.*.yml"],
+    {
+      "fileMatch": [".github/workflows/.*.yml"],
       "matchStrings": [
         "renovatebot datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION: (?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     }
-  ]
+  ],
+  "semanticCommitScope": "",
+  "semanticCommitType": "deps"
 }


### PR DESCRIPTION
Show dependency updates in release notes.

In order to have release notes share dependency updates (allowing consumers to traceback changes that may affect them), we reconfigure RenovateBot to change the `chore(deps):` to `deps` in dependency-update PRs.  Hope it'll make the sep-changes more obvious.