### PR TITLE
feat: provide an example to help test connectivity

### DIFF
--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -23,4 +23,11 @@ words:
   - chickenandpork
   - kwargs
   - osbee
+  - pypi
+  - rssi
   - srcs
+  - trem
+  - utct
+  - venv
+  - zbits
+  - zons

--- a/README.md
+++ b/README.md
@@ -3,3 +3,46 @@ Utilities for OSBee-3.0 device from OpenSprinkler
 
 The OSBeeAPI class wraps an async client of the OSBee REST API to make it look like a few
 independent valves.  Essentially split off from my HomeAssistant integration.
+
+
+## Can I talk to my OSBee?
+
+My personal OSBee is a v1.0.0; I've been chatting with someone whose v1.0.2 behaves a bit
+differently.  examples/dump_status.py can be used to connect to an OSBee and see if we can read the
+status of the valves and the OSBee in general.
+
+    python3 -m venv osbee_testing
+    source osbee_testing/bin/activate
+    pip install osbee
+    python3 examples/dump_status.py
+    deactivate
+
+You *should* see the status of your OSBee dumped out:
+
+    $ python3 examples/dump_status.py
+    type of timeout/max_runtime is <class 'int'>
+    created OSBeeAPI at 192.168.0.1 max_runtime 30 (<class 'int'>)
+    {
+        "cid": 5437235,
+        "fwv": 100,
+        "mac": "C45BBE123456",
+        "mnp": 6,
+        "name": "My OSBee WiFi",
+        "np": 0,
+        "nt": 0,
+        "pid": -1,
+        "prem": 0,
+        "rssi": -59,
+        "sot": 1,
+        "tid": -1,
+        "trem": 0,
+        "utct": 1716967540,
+        "zbits": 0,
+        "zons": [
+            "Zone 1",
+            "Zone 2",
+            "Zone 3"
+        ]
+    }
+
+If you see an exception and/or stack-trace, file an Issue in github and let's chat about it.

--- a/examples/dump_status.py
+++ b/examples/dump_status.py
@@ -1,0 +1,21 @@
+"""Connect to an OSBee and parse/dump status (the /jc method), showing we understand that OSBee."""
+
+import aiohttp
+import asyncio
+from json import dumps
+from osbee import OSBeeAPI
+
+
+async def main():
+    async with aiohttp.ClientSession() as client:
+
+        host = "192.168.0.1"
+        token = "opendoor"  # default password for OSBee
+
+        # The (0) (index) in fetch_data didn't pan out, may disappear
+        body = await OSBeeAPI(host, 30, token, client).fetch_data(0)
+
+        print(dumps(body, indent=4, sort_keys=True))
+
+
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 keywords = ["osbee", "opensprinkler"]
 # yup, pure bog-standard python
-dependencies = []
+dependencies = [ "aiohttp", "typing" ]
 #requires-python = ">=3.9"
 
 [project.optional-dependencies]

--- a/src/osbee/__init__.py
+++ b/src/osbee/__init__.py
@@ -1,2 +1,4 @@
 # Version of the realpython-reader package
 __version__ = "0.1.1"
+
+from .osbee import OSBeeAPI


### PR DESCRIPTION
- Added type hints
- Added example/dump_status.py to show a simple connection

This dump_status can be used to work through any connectivity differences or to check when outputs skew from upstream firmware changes.