### PR TITLE
fix: ignore content-type: do not fail on proper application/json

### DIFF
--- a/src/osbee/osbee.py
+++ b/src/osbee/osbee.py
@@ -71,7 +71,7 @@ class OSBeeAPI:
                     f"Error connecting to OSBee Hub (HTTP/{jc_request.status or 'None'})"
                 )
 
-            jc_body = await jc_request.json(content_type="text/html")
+            jc_body = await jc_request.json(content_type=None)
             if len(jc_body) == 0:
                 raise Exception(  # pylint: disable=broad-exception-raised
                     "The server returned a zero-length body, not a valid response"


### PR DESCRIPTION
Finding that firmware v1.0.2 uses the correct content-type, let's not punish it, but we need to accommodate v1.0.0 (that doesn't use the correct content-type).  ...so just ignore it since we kinda don't care.