### PR TITLE
fix: react to homeassistant bombing typing in constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
 ]
 keywords = ["osbee", "opensprinkler"]
 # yup, pure bog-standard python
-dependencies = [ "aiohttp", "typing" ]
+# NOTE: we use tpying, but homeassistant has bombed that out in constraints.txt, so we cannot list it here
+dependencies = [ "aiohttp" ]
 #requires-python = ">=3.9"
 
 [project.optional-dependencies]
@@ -24,3 +25,10 @@ dev = [ "black" ]
 
 [project.urls]
 Homepage = "https://github.com/chickenandpork/osbee"
+Repository = "https://github.com/chickenandpork/osbee.git"
+Issues = "https://github.com/chickenandpork/osbee/issues"
+Changelog = "https://github.com/chickenandpork/osbee/blob/master/CHANGELOG.md"
+
+[tool.black]
+line-length = 100
+target-version = ['py39']


### PR DESCRIPTION
For some reason, https://github.com/home-assistant/core/blob/dev/homeassistant/package_constraints.txt#L98 uses a ridiculous version of `typing` to make any such dependency conflict: since `typing` won't likely have version `1000000000.0.0`, no declaration of `typing` will succeed.

This is a nuisance since it works just fine locally, but fails in prod.

This PR might fail.  I cannot test this before merging and publishing.